### PR TITLE
Converted to PyMongo from MongoEngine, also fixed zipLists

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ This is a tool to compare two users' steam games with two modes:
 1. Full Compare
   * This grabs detailed information about each game and splits the results into three lists: Coop, Multiplayer, and Useless based on the Categories on the games
 
-pip 3 install requests mongoengine flask
+Dependencies:
+* Requests
+* PyMongo
+* Flask


### PR DESCRIPTION
Removed all MongoEngine code and instead use PyMongo to access the local DB. This increases performance by a factor of 7.

Using two users, one with 431 games, one with 4700 response times went from 130+ seconds to 16.

ZipLists now always matches all games the two users share