### PR TITLE
Multiple Bugfixes, update DB content, update response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ settings.json
 node_modules/
 node_modules/
 __pycache__/
+.vscode/

--- a/SteamGameCompare.py
+++ b/SteamGameCompare.py
@@ -97,12 +97,18 @@ def playersToDict(players):
 
 def zipLists(a, b):
     result = []
-    fullList = a.copy()
-    fullList.extend(b)
+    fullList = []
+    for item in a:
+        fullList.append(item)
+    for item in b:
+        fullList.append(item)
     for g in fullList:
         if g in a:
             if g in b:
-                result.append(g)
+                if g not in result:
+                    result.append(g)
+    for game in result:
+        print(game['name'])
     return result
 
 
@@ -274,19 +280,23 @@ def determineProperList(game):
 
 # This is for console output and will, likely, be removed eventually
 
-def printSharedGames(coop, multi, useless):
+def printSharedGames(gameList):
+    games = gameList['games']
     print (bcolors.BOLD + bcolors.OKGREEN \
             + "Here's the Coop games you share:" + bcolors.ENDC)
-    for game in coop:
-        print('\t' + game['name'])
+    for game in games:
+        if "coop" in game['multi']:
+            print('\t' + game['name'])
     print (bcolors.BOLD + bcolors.OKGREEN \
             + "Here's the Multiplayer games you share:" + bcolors.ENDC)
-    for game in multi:
-        print('\t' + game['name'])
+    for game in games:
+        if "multiplayer" in game['multi']:
+            print('\t' + game['name'])
     print (bcolors.BOLD + bcolors.OKGREEN \
         + "Here's the Useless games you share:" + bcolors.ENDC)
-    for game in useless:
-        print('\t' + game['name'])
+    for game in games:
+        if "singleplayer" in game['multi']:
+            print('\t' + game['name'])
 
 
 def getPlayerData(player):
@@ -350,33 +360,35 @@ def fullCompare():
         if errorResponse != {}:
             return (jsonify(errorResponse), 406)
         zipped = zipLists(playerList1, playerList2)
-        coop = []
-        multi = []
-        useless = []
         master = {}
+        games = []
         for game in zipped:
+            game['multi'] = []
             list = determineProperList(game)
-
-      # print(game['name'] + " has a score of " + str(list))
-
-            if list == 1 or list == 3:
-                coop.append(game)
-            elif list == 2 or list == 3:
-                multi.append(game)
+            if list == 1:
+                game['multi'].append("coop")
+                games.append(game)
+            elif list == 2:
+                game['multi'].append("multiplayer")
+                games.append(game)
+            elif list == 3:
+                if "multi" not in game['multi']:
+                    game['multi'].append("multiplayer")
+                if "coop" not in game['multi']:
+                    game['multi'].append("coop")
+                games.append(game)
             elif list == 0:
-                useless.append(game)
+                game['multi'].append("singleplayer")
+                games.append(game)
             else:
                 print ('the value of list was ' + str(list) + '...')
         playerData = [player1, player2]
         master['players'] = playersToDict(playerData)
-        master['coop'] = coop
-        master['multi'] = multi
-        master['useless'] = useless
+        master['games'] = games
 
     # print(bcolors.BOLD + bcolors.FAIL + 'Info for Games Shared Between ' + players[0].name + ' & ' + players[1].name + bcolors.ENDC)
 
-        printSharedGames(master['coop'], master['multi'],
-                         master['useless'])
+        printSharedGames(master)
         return jsonify(master)
     else:
         abort(401)

--- a/SteamGameCompare.py
+++ b/SteamGameCompare.py
@@ -67,6 +67,7 @@ STEAM_APP_ERROR_TYPE = [{
 steamOwnedGamesBaseURI = 'https://api.steampowered.com/'
 steamGameInfoBaseURI = 'http://store.steampowered.com/api/'
 steamPlayerInfoBaseURI = 'http://api.steampowered.com/'
+steamMediaBaseURI = 'http://media.steampowered.com/steamcommunity/public/images/apps/'
 
 # A filler DB entry for games that have no categories
 
@@ -98,10 +99,10 @@ def zipLists(a, b):
     result = []
     fullList = a.copy()
     fullList.extend(b)
-    for game in fullList:
-        if game in a:
-            if game in b:
-                result.append(game)
+    for g in fullList:
+        if g in a:
+            if g in b:
+                result.append(g)
     return result
 
 
@@ -114,11 +115,14 @@ def lookupSingle(gameID):
                          + str(gameID))
         gameJSON = json.loads(r.text)
         if r.text == 'null':
-            return 0
-        if gameJSON[str(gameID)]['success'] == False:
-            return 1
-        if gameID != gameJSON[str(gameID)]['data']['steam_appid']:
-            return 2
+            return 0, gameJSON
+        elif gameJSON[str(gameID)]['success'] == False:
+            return 1, gameJSON
+        elif gameID != gameJSON[str(gameID)]['data']['steam_appid']:
+            return 2, gameJSON
+        else:
+            return 3, gameJSON
+
 
 
 def buildQuickGameList(id):
@@ -146,10 +150,9 @@ def buildQuickGameList(id):
 def buildUserGameList(id, debug=False):
     gameList = []
     userListRaw = requests.get(steamOwnedGamesBaseURI
-                               + '/IPlayerService/GetOwnedGames/v1/?key='
-                                + webKey + '&steamId=' + str(id)
-                               + '&include_appinfo=1&include_played_free_games=&format=json'
-                               )
+                                + '/IPlayerService/GetOwnedGames/v1/?key=' \
+                                + webKey + '&steamId=' + str(id) \
+                                + '&include_appinfo=1&include_played_free_games=1&format=json')
 
   # Use this to tell which game(s) break on a steam library (SHould no longer be needed, but keeping it just in case)
   # f = open("debug.txt", 'w')
@@ -170,26 +173,36 @@ def buildUserGameList(id, debug=False):
         userGames = userListJSON['response']['games']
         totalGames = len(userGames)
         gameCursor = 0
-        for game in userGames:
+        for g in userGames:
 
       # This is/was for console output - Mostly because as of writing this, there's no frontend and sending people JSON is not as...parseable
-      # print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
-
+            print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
             gameCursor += 1
-            userAppId = str(game['appid'])
-            gameDetails = lookupSingle(game['appid'])
-            if gameDetails == 0:
+            userAppId = str(g['appid'])
+            gameStatus = lookupSingle(g['appid'])
+            if isinstance(gameStatus, dict):
+                gameStatus['thumbnail'] = steamMediaBaseURI + userAppId + '/' + g['img_logo_url'] + '.jpg'
+                gameStatus['steam_url'] = 'http://store.steampowered.com/app/' + userAppId
+                gameList.append(gameStatus)
+            elif gameStatus[0] == 0:
 
         # This is the Rate-limited case
         # Maybe there should be some logic here for waiting.
 
                 pass
-            elif gameDetails == 1:
+            elif gameStatus[0] == 1:
 
         # This is the success=false case
-
-                pass
-            elif gameDetails == 2:
+                game.insert_one({'name':g['name'],
+                                'appid':g['appid'],
+                                'categories':[nullCategory],
+                                'unavailable':True})
+                newGame = game.find_one({'appid':int(userAppId)},{'_id': False})
+                newGame['thumbnail'] = steamMediaBaseURI + userAppId + '/' + g['img_logo_url'] + '.jpg'
+                newGame['steam_url'] = 'http://store.steampowered.com/app/' + userAppId
+                gameList.append(newGame)
+            elif gameStatus[0] == 2:
+                gameDetails = gameStatus[1]
 
         # This is the case where Multiple games return the game details for the same game
         # This happens with Expansion packs that are no longer for individual sale often.
@@ -199,27 +212,49 @@ def buildUserGameList(id, debug=False):
 
           # The game whose details were returned we have info for
 
-                    if not game.find_one({"appid":game['appid']}):
+                    if not game.find_one({"appid":g['appid']}):
 
             # We do not have an ID with the game we searched for
 
                         if 'categories' in gameDetails[userAppId]['data']:
-                            game.insert_one({'name':game['name'],
-                                    'appid':game['appid'],
-                                    'categories':gameDetails[userAppId]['data'
-                                    ]['categories']})
-                            gameList.append(game.find_one({'appid':userAppId},{'_id': False}))
+                            game.insert_one({'name':g['name'],
+                                            'appid':g['appid'],
+                                            'categories':gameDetails[userAppId]['data']['categories'],
+                                            'platforms':gameDetails[userAppId]['data']['platforms'],
+                                            'is_free':gameDetails[userAppId]['data']['is_free']})
+                            newGame = game.find_one({'appid':int(userAppId)},{'_id': False})
+                            newGame['thumbnail'] = steamMediaBaseURI + userAppId + '/' + g['img_logo_url'] + '.jpg'
+                            newGame['steam_url'] = 'http://store.steampowered.com/app/' + userAppId
+                            gameList.append(newGame)
                         else:
-                            game.insert_one({'name':game['name'],
-                                    'appid':game['appid'],
-                                    'categories':[nullCategory]})
-                            gameList.append(game.find_one({'appid':userAppId},{'_id': False}))
-                    elif game.find_one({'appid':game['appid']}):
-                        gameList.append(game.find_one({'appid':userAppId},{'_id': False}))
+                            game.insert_one({'name':g['name'],
+                                            'appid':g['appid'],
+                                            'categories':[nullCategory],
+                                            'platforms':gameDetails[userAppId]['data']['platforms'],
+                                            'is_free':gameDetails[userAppId]['data']['is_free']})
+                            newGame = game.find_one({'appid':int(userAppId)},{'_id': False})
+                            newGame['thumbnail'] = steamMediaBaseURI + userAppId + '/' + g['img_logo_url'] + '.jpg'
+                            newGame['steam_url'] = 'http://store.steampowered.com/app/' + userAppId
+                            gameList.append(newGame)
+                    elif game.find_one({'appid':g['appid']}):
+                        newGame = game.find_one({'appid':int(userAppId)},{'_id': False})
+                        newGame['thumbnail'] = steamMediaBaseURI + userAppId + '/' + g['img_logo_url'] + '.jpg'
+                        newGame['steam_url'] = 'http://store.steampowered.com/app/' + userAppId
+                        gameList.append(newGame)
                     else:
                         pass
-            elif isinstance(gameDetails, dict):
-                gameList.append(gameDetails)
+            elif gameStatus[0] == 3:
+                newGameRaw = gameStatus[1]
+                newGame = newGameRaw[userAppId]['data']
+                newGameInsert = db.game.insert_one({'appid':newGame['steam_appid'],
+                                                    'name':newGame['name'],
+                                                    'categories':newGame['categories'],
+                                                    'platforms':newGame['platforms'],
+                                                    'is_free':newGame['is_free']})
+                foundGame = game.find_one({'appid':int(userAppId)},{'_id': False})
+                foundGame['thumbnail'] = steamMediaBaseURI + userAppId + '/' + g['img_logo_url'] + '.jpg'
+                foundGame['steam_url'] = 'http://store.steampowered.com/app/' + userAppId
+                gameList.append(foundGame)
     return gameList
 
 
@@ -380,15 +415,9 @@ def quickCompare():
         zipped = zipLists(playerList1['response']['games'],
                           playerList2['response']['games'])
         master = {}
-        games = []
-        for game in zipped:
-            tempGame = {}
-            tempGame['name'] = game['name']
-            tempGame['appid'] = game['appid']
-            games.append(tempGame)
         playerData = [player1, player2]
         master['players'] = playersToDict(playerData)
-        master['games'] = games
+        master['games'] = zipped
         return jsonify(master), 200
     else:
         abort(401)

--- a/populateAppList.py
+++ b/populateAppList.py
@@ -1,15 +1,13 @@
-from mongoengine import *
+from pymongo import MongoClient
 import requests
 import json
 import datetime
 import time
 
 
-class Game(Document):
-  name = StringField(required=True)
-  appid = DecimalField(required=True)
-  categories = ListField(required=True)
-  date_modified = DateTimeField(default=datetime.datetime.utcnow)
+client = MongoClient()
+db = client.gameData
+game = db.game
 
 settings = json.load(open('settings.json'))
 
@@ -19,86 +17,148 @@ steamGameInfoBaseURI = 'http://store.steampowered.com/api/'
 steamPlayerInfoBaseURI = 'http://api.steampowered.com'
 nullCategory = [{"id":0,"description":"This Game has No Categories"}]
 
+def lookupSingle(gameID):
+    gameData = game.find_one({'appid':gameID},{'_id': False})
+    if gameData is not None:
+        return gameData
+    else:
+        r = requests.get(steamGameInfoBaseURI + 'appdetails?appids='
+                         + str(gameID))
+        gameJSON = json.loads(r.text)
+        if r.text == 'null':
+            return 0, gameJSON
+        elif gameJSON[str(gameID)]['success'] == False:
+            return 1, gameJSON
+        else:
+            return 2, gameJSON
 
-def gameToDict(game):
-  dict = {}
-  for boop in game:
-    dict['name'] = boop.name
-    dict['appid'] = int(boop.appid)
-    dict['categories'] = boop.categories
-  return dict
-
-connect()
 
 r = requests.get('https://api.steampowered.com/ISteamApps/GetAppList/v2/')
 gameRaw = json.loads(r.text)
-fullGameList = gameRaw['applist']['apps']
+fullAppList = gameRaw['applist']['apps']
 
-totalGames = len(fullGameList)
-iteration = 1
+localAppList = game.find({},{'_id':False})
+outOfDateApps = []
+
+for gameData in localAppList:
+    if 'is_free' in gameData and 'platforms' in gameData: 
+        pass
+    elif 'unavailable' in gameData:
+        pass
+    else: 
+        outOfDateApps.append(gameData)
+
+
+
+totalGames = len(outOfDateApps)
+print(totalGames)
 gameCursor = 0
-#Use this to tell which game(s) break on a steam library
-#f = open("debug.txt", 'w')
-#f.write(r.text)
 
-for game in fullGameList:
-    print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
+for g in outOfDateApps:
+    #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
     gameCursor += 1
-    #print('Working on '+ game['name'] + ' (' + str(iteration) + ' of ' + str(totalGames) + ' ' + str(100*(iteration/totalGames)) + '%)')
-    iteration += 1
-    userAppId = str(game['appid'])
-    if Game.objects(appid=userAppId):
-      pass
-    else:
-        r = requests.get(steamGameInfoBaseURI + 'appdetails?appids=' + userAppId)
-        gameInfo = json.loads(r.text)
-        if r.text == 'null':
-          print("Game is Null, waiting 5 minutes (" + userAppId + " " + game['name'] + ")")
-          timer = 0
-          while timer < 300:
-            timer += 1
-            time.sleep(1)
-            print(f"{gameCursor/totalGames*100:.1f} % (" + str(300-timer) + " seconds remaining)", end="\r")
-          retry = requests.get(steamGameInfoBaseURI + 'appdetails?appids=' + userAppId)
-          gameInfoRetry = json.loads(retry.text)
-          try:
-            attempt = gameInfoRetry[userAppId]
-            if gameInfoRetry[userAppId]["success"] == "false":
-              newGame = Game(name=game["name"],appid=game["appid"],
-                             categories=nullCategory).save()
-              print("Added " + game['name'] + " to DB")
-              print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
-            elif gameInfoRetry[userAppId]["data"]["steam_appid"] != userAppId:
-              newGame = Game(name=game["name"],appid=game["appid"],
-                             categories=nullCategory).save()
-              print("Added " + gameInfo[userAppId]["data"]['name'] + " to DB")
-              print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
-          except:
-            pass
-            print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
-        elif gameInfo[userAppId]["success"]== False:
-          #print("Game is broken, skipping (" + userAppId + " " + game['name'] + ")")
-          newGame = Game(name=game["name"],appid=game["appid"],
-                             categories=nullCategory).save()
-          print("Added " + game['name'] + " to DB")
-          print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
-          pass
-          time.sleep(.75)
-        else:
-          if Game.objects(appid=gameInfo[userAppId]['data']['steam_appid']):
-            #print("Multiple Games redirect to this same AppID: " + str(gameInfo[userAppId]['data']['steam_appid']))
-            newGame = Game(name=game["name"],appid=game["appid"],
-                             categories=nullCategory).save()
-            print("Added " + gameInfo[userAppId]["data"]['name'] + " to DB (Multiple Games redirect to this appid)")
-            print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
-            time.sleep(.75)
-          else:
-            print("Adding " + gameInfo[userAppId]["data"]['name'] + " to DB (" + userAppId + ")")
-            if "categories" in gameInfo[userAppId]["data"]:
-              newGame = Game(name=gameInfo[userAppId]["data"]['name'],appid=gameInfo[userAppId]["data"]["steam_appid"],
-                             categories=gameInfo[userAppId]["data"]["categories"]).save()
-              print("Added " + gameInfo[userAppId]["data"]['name'] + " to DB")
-              time.sleep(.75)
+    userAppId = str(int(g['appid']))
+    gameLookup = lookupSingle(g['appid'])
+    if isinstance(gameLookup, tuple):
+        gameResult = gameLookup[0]
+        gameDetails = gameLookup[1]
+        if gameResult == 0:
+            print("Game is Null, waiting 5 minutes (" + userAppId + " " + g['name'] + ")")
+            timer = 0
+            while timer < 300:
+                timer += 1
+                time.sleep(1)
+                print(f"{gameCursor/totalGames*100:.1f} % (" + str(300-timer) + " seconds remaining)", end="\r")
+            retry = lookupSingle(userAppId)
+            gameInfoRetry = retry[1]
+            if retry[0] == 0:
+                print(g['name'] + "was not added, double nulled")
+                pass
+            elif retry[0] == 1:
+                game.insert_one({'name':g['name'],
+                                'appid':g['appid'],
+                                'categories':nullCategory,
+                                'unavailable':True})
+                print("Added " + g['name'] + " to DB - But game is unavailable to buy")
+                time.sleep(.5)
+                #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
+            elif retry[0] == 2:
+                if 'categories' in gameInfoRetry[userAppId]['data']:
+                    game.insert_one({'name':g['name'],
+                                    'appid':g['appid'],
+                                    'categories':gameInfoRetry[userAppId]['data']['categories'],
+                                    'platforms':gameInfoRetry[userAppId]['data']['platforms'],
+                                    'is_free':gameInfoRetry[userAppId]['data']['is_free']})
+                    print("Added " + g['name'] + " to DB")
+                    time.sleep(.5)
+                    #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
+                else:
+                    game.insert_one({'name':g['name'],
+                                    'appid':g['appid'],
+                                    'categories': nullCategory,
+                                    'platforms':gameInfoRetry[userAppId]['data']['platforms'],
+                                    'is_free':gameInfoRetry[userAppId]['data']['is_free']})
+                    print("Added " + g['name'] + " to DB")
+                    time.sleep(.5)
+                    #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
+        elif gameResult == 1:
+            game.insert_one({'name':g['name'],
+                            'appid':g['appid'],
+                            'categories':nullCategory,
+                            'unavailable':True})
+            print("Added " + g['name'] + " to DB - But game is unavailable to buy")
+            time.sleep(.5)
+            #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
+        elif gameResult == 2:
+            if 'categories' in gameDetails[userAppId]['data']:
+                game.insert_one({'name':g['name'],
+                                'appid':g['appid'],
+                                'categories':gameDetails[userAppId]['data']['categories'],
+                                'platforms':gameDetails[userAppId]['data']['platforms'],
+                                'is_free':gameDetails[userAppId]['data']['is_free']})
+                print("Added " + g['name'] + " to DB")
+                time.sleep(.5)
+                #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
             else:
-              newGame = Game(name=gameInfo[userAppId]["data"]['name'],appid=gameInfo[userAppId]["data"]["steam_appid"],
-                             categories=[nullCategory]).save()
+                game.insert_one({'name':g['name'],
+                                'appid':g['appid'],
+                                'categories': nullCategory,
+                                'platforms':gameDetails[userAppId]['data']['platforms'],
+                                'is_free':gameDetails[userAppId]['data']['is_free']})
+                print("Added " + g['name'] + " to DB")
+                time.sleep(.5)
+                #print(f"{gameCursor/totalGames*100:.1f} %", end="\r")
+    elif isinstance(gameLookup, dict):
+        #print(f"{gameCursor/totalGames*100:.1f} % (" + gameLookup['name'] + ")", end="\r")
+        r = requests.get(steamGameInfoBaseURI + 'appdetails?appids='
+                         + userAppId)
+        gameDetails = json.loads(r.text)
+        if gameDetails == 'null':
+            print("Game is Null, waiting 5 minutes (" + userAppId + " " + g['name'] + ")")
+            timer = 0
+            while timer < 300:
+                timer += 1
+                time.sleep(1)
+                print(f"{gameCursor/totalGames*100:.1f} % (" + str(300-timer) + " seconds remaining)", end="\r")
+        else:
+            try:
+                if gameDetails[userAppId]['success'] == False:
+                    game.replace_one({'appid':gameLookup['appid']},
+                                    {'name':gameLookup['name'],
+                                    'appid':gameLookup['appid'],
+                                    'categories':nullCategory,
+                                    'unavailable':True})
+                    print('Updated game: '+ gameLookup['name'])
+                    time.sleep(.5)
+                else:
+                    game.replace_one({'appid':gameLookup['appid']},
+                                    {'name':gameLookup['name'],
+                                    'appid':gameLookup['appid'],
+                                    'categories':gameLookup['categories'],
+                                    'platforms':gameDetails[userAppId]['data']['platforms'],
+                                    'is_free':gameDetails[userAppId]['data']['is_free']})
+                    print('Updated game: '+ gameLookup['name'])
+                    time.sleep(.5)
+            except TypeError:
+                print (gameDetails)
+


### PR DESCRIPTION
Several things were done here:

1) Updated both SteamGameCompare and populateGameList to add new games/update existing ones to include "is_free" and "platforms" if details are returned. "unavailable" is added if game details are not returned (due to "success":False)

2) lookupSingle now returns a tuple if the game is not present in the DB (a return code to say the response type and a dict of the details). If the game is in the DB, just returns a dict with the details.

3) fullCompare now does not build three lists (coop, multi, useless) and return those. instead each game gets a "multi" list attribute added to it that can have up to three strings in it: "multiplayer", "coop", "singleplayer"

4) fixed a bug with zipLists so that it doesn't double add every game both players share.

5) Updated populateGameList to fetch all games that need to be updated (and made it easier to define what attributes you want to look for to check) and all apps not in DB, then to update or add those.

6) Every game in the fullCompare has it's thumbnail and steam web page url added to the details.